### PR TITLE
Small issues and worker API normalization

### DIFF
--- a/engine/combos.es6
+++ b/engine/combos.es6
@@ -1,3 +1,4 @@
+'use strict';
 
 const utils = require('./utils.es6');
 
@@ -32,7 +33,7 @@ let combinations = function(terms, k, replacement) {
     combos = combos.concat(subCombos.map((combo) => [terms[i]].concat(combo)));
   }
   return combos;
-}
+};
 
 /**
  * Generates all combinations of k items using one item from each bin in `bins`.
@@ -63,7 +64,7 @@ let combinationsFromBins = function(bins, k) {
     combos = combos.concat(subCombos.map((combo) => [bins[0][i]].concat(combo)));
   }
   return combos.concat(combinationsFromBins(bins.slice(1), k));
-}
+};
 
 /**
  * Generates all possible combinations of exponentiated terms given a list of
@@ -83,7 +84,7 @@ let generateTerms = function(features, exponents, multipliers) {
     , combosForMults = multipliers.map((m) => combinationsFromBins(bins, m));
 
   return [].concat.apply([], combosForMults);
-}
+};
 
 module.exports.generateTerms = generateTerms;
 module.exports.combinations = combinations;

--- a/engine/index.es6
+++ b/engine/index.es6
@@ -1,6 +1,6 @@
 
 const Model   = require('./model.es6');
-const utils   = require('./playground/utils.es6');
+const utils   = require('./utils.es6');
 const Matrix  = require('./matrix').Matrix;
 const combos  = require('./combos.es6');
 

--- a/engine/index.es6
+++ b/engine/index.es6
@@ -8,14 +8,14 @@ const combos  = require('./combos.es6');
 // TODO: replace input to model() with object per data contract once it is
 //       finalized
 
-module.exports.model = (data, indepCol, exponents, multipliers) => {
-  indepCol = indepCol || (data.size()[1] - 1);
+module.exports.model = (data, dependent, exponents, multipliers) => {
+  dependent = dependent || (data.size()[1] - 1);
   data = new Matrix(data);
 
   var inputColumns = data.subset(
     ':',
-    utils.range(0, indepCol).concat(utils.range(indepCol + 1, data.shape[1]))
-  ) , outputColumn = data.col(indepCol);
+    utils.range(0, dependent).concat(utils.range(dependent + 1, data.shape[1]))
+  ) , outputColumn = data.col(dependent);
 
   return new Model(inputColumns, outputColumn, exponents, multipliers);
 };

--- a/engine/matrix/matrix.es6
+++ b/engine/matrix/matrix.es6
@@ -122,6 +122,18 @@ class Matrix {
   }
 
   /**
+   * Set the element at the ith row and jth column.
+   *
+   * @param {number} i s.t. 0 <= i < m
+   * @param {number} j s.t. 0 <= i < n
+   * @param {number} value To replace the existing one
+   * @return {number} Element at (i, j)
+   */
+  set(i, j, value) {
+    return this[_data][i * this[_n] + j] = value;
+  }
+
+  /**
    * Performs element-wise addition between two matrices and returns a new copy.
    *
    * @param {Matrix<m,n>} other Matrix with equivalent dimensions to this
@@ -400,14 +412,24 @@ class Matrix {
   }
 
   /**
-   * Retrieves the ith column of the matrix
+   * Retrieves/sets the ith column of the matrix
    *
-   * @param {number} i Column index
+   * @param {number}    i         Column index
+   * @param {number[]}  [newCol]  Elements to replace the col with
    * @return {Matrix<m,1>} Column as a matrix
    */
-  col(i) {
+  col(i, newCol) {
     var theCol = new Matrix(this[_m], 1)
       , k;
+
+    if (newCol != null) {
+      if (newCol.length > this[_m]) {
+        throw new RangeError('newCol cannot be longer than ' + this[_m]);
+      }
+      for (k = 0; k < this[_m]; k += 1) {
+        this[_data][k * this[_n] + i] = newCol[k];
+      }
+    }
 
     for (k = 0; k < this[_m]; k += 1) {
       theCol[_data][k] = this[_data][k * this[_n] + i];
@@ -416,12 +438,19 @@ class Matrix {
   }
 
   /**
-   * Retrieves the ith row of the matrix
+   * Retrieves/sets the ith row of the matrix
    *
-   * @param {number} i Row index
+   * @param {number}    i         Row index
+   * @param {number[]}  [newRow]  Elements to replace the row with
    * @return {Matrix<1,n>} Row as a matrix
    */
-  row(i) {
+  row(i, newRow) {
+    if (newRow != null) {
+      if (newRow.length > this[_n]) {
+        throw new RangeError('newRow cannot be longer than ' + this[_n]);
+      }
+      this[_data].subarray(i * this[_n]).set(newRow);
+    }
     return new Matrix(
       1, this[_n],
       this[_data].slice(i * this[_n], (i+1) * this[_n])

--- a/interface/adapter/worker.coffee
+++ b/interface/adapter/worker.coffee
@@ -28,9 +28,10 @@ send = ( data ) ->
 module.exports =
   send_model: ( grid, dependant, exponents, multiplicands ) ->
     worker.postMessage
-      type: "new_model"
-      data: grid
-      indepCol: dependant
-      exponents: exponents
-      multiplicands: multiplicands
+      type: "update_model"
+      data:
+        model: grid
+        dependent: dependant
+        exponents: exponents
+        multiplicands: multiplicands
     send type: "get_terms"

--- a/interface/components/content/index.coffee
+++ b/interface/components/content/index.coffee
@@ -19,7 +19,7 @@ ko.components.register "tf-content",
 
       adapter.send_model([
         [ 0, 0, 0, 0 ]
-      ], 3, exponents, multiplicands).then ( {candidates} ) =>
+      ], 3, exponents, multiplicands).then ( candidates ) =>
         @candidates candidates
 
     @candidates = ko.observable [ ]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "taylorfit",
   "main": "index.js",
   "scripts": {
-    "build": "npm install && npm run build:engine && webpack",
+    "build": "npm install && webpack",
     "build:engine": "browserify engine/index.es6 -o build/engine.js -s engine --noparse node_modules/mathjs/dist/math.min.js -t [ babelify --presets [ es2015 ] ]",
     "build:worker": "browserify worker/worker.es6 -o worker/bundle.js -s worker -t [ babelify --presets [ es2015 ] ]",
     "debug": "npm install && webpack-dev-server --inline --hot",

--- a/test/engine/model.test.js
+++ b/test/engine/model.test.js
@@ -24,7 +24,7 @@ describe('Model', () => {
   describe('constructor()', () => {
 
     it('accepts an input data matrix and an expected output vector', () => {
-      var m = new Model(data.X, data.y, [1, 2], [1]);
+      var m = new Model(data.X, data.y, [1, 2], 1);
       expect(m.X).to.eql(data.X);
       expect(m.weights).to.eql([]);
       expect(m.terms).to.eql([]);
@@ -32,7 +32,7 @@ describe('Model', () => {
 
     it('computes an augmented matrix if a list of terms is given', () => {
       var terms = combos.generateTerms(data.X.shape[1], [1, 2], [1]);
-      var m = new Model(data.X, data.y, [1, 2], [1], terms);
+      var m = new Model(data.X, data.y, [1, 2], 1, terms);
 
       m.terms.forEach((term, i) => {
         expect(data.X.subset(':', term.term[0][0]).dotPow(term.term[0][1]))
@@ -45,7 +45,7 @@ describe('Model', () => {
   describe('addTerm()', () => {
 
     it('accepts a valid term [[column, exponent], ...]', () => {
-      var m = new Model(data.X, data.y, [1, 2], [1, 2]);
+      var m = new Model(data.X, data.y, [1, 2], 2);
 
       m.addTerm([[0, 1]]);
       expect(m.terms.map((t) => t.term)).to.include.deep.members([[[0, 1]]]);
@@ -63,7 +63,7 @@ describe('Model', () => {
     });
 
     it('does not add duplicate terms', () => {
-      var m = new Model(data.X, data.y, [1, 2], [1]);
+      var m = new Model(data.X, data.y, [1, 2], 1);
 
       m.addTerm([[0, 1]]);
       expect(m.terms.map((t) => t.term)).to.include.deep.members([[[0, 1]]]);
@@ -96,7 +96,7 @@ describe('Model', () => {
   describe('removeTerm()', () => {
 
     it('removes an existing term', () => {
-      var m = new Model(data.X, data.y, [1, 2], [1, 2]);
+      var m = new Model(data.X, data.y, [1, 2], 2);
 
       m.addTerm([[0, 1]]);
       expect(m.terms.map((t) => t.term)).to.include.deep.members([[[0, 1]]]);

--- a/test/engine/term.test.js
+++ b/test/engine/term.test.js
@@ -26,7 +26,7 @@ describe('Term', () => {
     var m;
 
     before(() => {
-      m = new Model(data.X, data.y, [1, 2], [1, 2]);
+      m = new Model(data.X, data.y, [1, 2], 2);
     });
 
     it('creates a new term given a valid set of pairs and a model', () => {
@@ -49,7 +49,7 @@ describe('Term', () => {
     var m;
 
     before(() => {
-      m = new Model(data.X, data.y, [1, 2], [1, 2]);
+      m = new Model(data.X, data.y, [1, 2], 2);
     });
 
     it('returns the t-statistic and MSE when the candidate term is included', () => {

--- a/worker/index.es6
+++ b/worker/index.es6
@@ -85,32 +85,41 @@ onmessage = function (e) {
 
   case 'get_terms':
     if (model == null) {
-      postMessage({ type: 'error', message: 'Model not instantiated' });
+      postMessage({ type: 'error', data: 'Model not instantiated' });
     }
     var terms = model.candidates.map((term) => term.term);
-    postMessage({ type: 'candidates', candidates: terms });
+    postMessage({
+      type: 'candidates',
+      data: terms
+    });
     break;
 
   case 'add_term':
     if (model == null) {
-      postMessage({ type: 'error', message: 'Model not instantiated' });
+      postMessage({ type: 'error', data: 'Model not instantiated' });
     }
-    console.log('yoyoyo', e.data.term);
-    model.addTerm(e.data.term, false);
-    var results = model.compute();
-    results.type = 'result';
-    postMessage(results);
+    console.log('yoyoyo', data);
+
+    model.addTerm(data, false);
+    postMessage({
+      type: 'candidates',
+      data: model.compute()
+    });
     break;
 
   case 'remove_term':
     if (model == null) {
-      postMessage({ type: 'error', message: 'Model not instantiated' });
+      postMessage({ type: 'error', data: 'Model not instantiated' });
     }
-    model.removeTerm(e.data.term);
+    model.removeTerm(data, false);
+    postMessage({
+      type: 'candidates',
+      data: model.compute()
+    });
     break;
 
   default:
-    postMessage({ type: 'error', message: 'Invalid type: ' + e.data.type });
+    postMessage({ type: 'error', data: 'Invalid type: ' + type });
 
   }
 };

--- a/worker/index.es6
+++ b/worker/index.es6
@@ -24,7 +24,7 @@ var model   = null;
  *                                        specify a location and value to
  *                                        replace
  */
-let updateModel = function (data) {
+var updateModel = function (data) {
   var dataset       = data.model || (model && model.X)
     , existingTerms = (model && model.terms.map((t) => t.term)) || []
     , dependent     = data.dependent
@@ -73,14 +73,21 @@ let updateModel = function (data) {
 };
 
 
+function log() {
+  console.debug('[Engine]:', ...arguments);
+}
+
 onmessage = function (e) {
   var type = e.data.type
     , data = e.data.data;
+
+  log(e.data);
 
   switch(type) {
 
   case 'update_model':
     updateModel(data);
+    log('new model:', model);
     break;
 
   case 'get_terms':
@@ -88,23 +95,15 @@ onmessage = function (e) {
       postMessage({ type: 'error', data: 'Model not instantiated' });
     }
     var terms = model.candidates.map((term) => term.term);
-    postMessage({
-      type: 'candidates',
-      data: terms
-    });
+    postMessage({ type: 'candidates', data: terms });
     break;
 
   case 'add_term':
     if (model == null) {
       postMessage({ type: 'error', data: 'Model not instantiated' });
     }
-    console.log('yoyoyo', data);
-
     model.addTerm(data, false);
-    postMessage({
-      type: 'candidates',
-      data: model.compute()
-    });
+    postMessage({ type: 'candidates', data: model.compute() });
     break;
 
   case 'remove_term':
@@ -112,10 +111,7 @@ onmessage = function (e) {
       postMessage({ type: 'error', data: 'Model not instantiated' });
     }
     model.removeTerm(data, false);
-    postMessage({
-      type: 'candidates',
-      data: model.compute()
-    });
+    postMessage({ type: 'candidates', data: model.compute() });
     break;
 
   default:

--- a/worker/main.js
+++ b/worker/main.js
@@ -16,19 +16,21 @@ engine.onmessage = function (e) {
 
 
 engine.postMessage({
-  type: 'new_model',
-  data: [[1, 2, 3, 4],
-         [3, 2, 1, 4],
-         [5, 6, 3, 2],
-         [3, 3, 2, 7],
-         [9, 8, 2, 6],
-         [3, 2, 3, 4]],
-  indepCol: 3,
-  exponents: [1],
-  multiplicands: [1]
+  type: 'update_model',
+  data: {
+    model: [[1, 2, 3, 4],
+            [3, 2, 1, 4],
+            [5, 6, 3, 2],
+            [3, 3, 2, 7],
+            [9, 8, 2, 6],
+            [3, 2, 3, 4]],
+    dependent: 3,
+    exponents: [1],
+    multiplicands: 1
+  }
 });
 
 //engine.postMessage({ type: 'get_terms' });
-engine.postMessage({ type: 'add_term', term: [[0, 1]] });
+engine.postMessage({ type: 'add_term', data: [[0, 1]] });
 engine.postMessage({ type: 'add_term', term: [[1, 1]] });
 


### PR DESCRIPTION
- Rename `indepCol` to `dependent` (closes #16).
- `multiplicands` arg is now a single number `n` which now represents the range `[1, n]` instead of being a list of individual valid multiplicands (closes #17).
- Create `'update_model'` event in worker to handle model deltas (changes in row, col, and item data) (closes #18).
  **Q: For items, the scheme shows [ [row, col, val], [row, col, val], ... ], allowing multiple item replacements. Should rows/cols work the same way? As of now they only support 1 row / 1 col replacement per event.**
- Normalize worker API messages to be of the format `{ type: string, data: * }`. The structure of `data` changes depending on the event type (closes #15).